### PR TITLE
Partial v4 fix

### DIFF
--- a/js/live2d.js
+++ b/js/live2d.js
@@ -45,7 +45,8 @@ async function _show(model) {
         debugLog: false,
         debugMouseLog: false,
         randomMotion: false,
-        defaultMotionGroup:"Motion"
+        defaultMotionGroup: "Motion",
+        autoInteract: follow
     });
     app.stage.addChild(live2dSprite);
     live2dSprite.scale.set(0.5, 0.5);

--- a/js/live2d.js
+++ b/js/live2d.js
@@ -46,7 +46,10 @@ async function _show(model) {
         debugMouseLog: false,
         randomMotion: false,
         defaultMotionGroup: "Motion",
-        autoInteract: follow
+        autoInteract: follow,
+        expressionFadingDuration: 0,
+        motionFadingDuration: 0,
+        idleMotionFadingDuration: 0
     });
     app.stage.addChild(live2dSprite);
     live2dSprite.scale.set(0.5, 0.5);

--- a/js/page.js
+++ b/js/page.js
@@ -116,8 +116,15 @@ $(document).ready(function() {
             for (let c in list) { sv.append($("<option></option>").text(c).val(list[c])) }
             sv.val("");
         });
-        se.change(function() { app.stage.children[0].internalModel.motionManager.expressionManager.setExpression(this.value) });
-        sm.change(function() { app.stage.children[0].internalModel.motionManager.startMotion("Motion", this.value) });
+        se.change(function() {
+            app.stage.children[0].internalModel.motionManager.stopAllMotions();
+            app.stage.children[0].internalModel.motionManager.startMotion("Motion", sm.val() ?? 0);
+            app.stage.children[0].internalModel.motionManager.expressionManager.setExpression(this.value)
+        });
+        sm.change(function() {
+            app.stage.children[0].internalModel.motionManager.stopAllMotions();
+            app.stage.children[0].internalModel.motionManager.startMotion("Motion", this.value)
+        });
         sv.change(function() { 
             //audio = app.stage.children[0].model.playSound(this.value + ".mp3", "/magica/resource/sound_native/voice/");
         });

--- a/pixi.html
+++ b/pixi.html
@@ -36,7 +36,7 @@
             <input id="width" type="number" value="1280" style="width:4em;" />*<input id="height" type="number" value="1600" style="width:4em;" />
             <button onclick="resize()">reload/resize</button>
             <label id="Lzoom">Zoom: 50%</label>
-            <input id="zoom" type="range" min="1" max="100" valu="50" />
+            <input id="zoom" type="range" min="1" max="100" value="50" />
             <button id="background">Background</button>
         </div>
         <div id="function">


### PR DESCRIPTION
- Fix `(un)follow` button by controlling `autoInteract` option with its flag.
When toggled to `false`, it won't T-pose, but cursor is ignored.

- Partial fix for overlapping expressions.
Resetting motion on changing expressions allows to actually drop current expression.
It doesn't solve **all** problems tho. Expressions are still bugged, and dunno what exactly causes eyebrow drift.

- Disable fading durations setted by magireco files.
Allows to switch expressions instantly even for long motions.