### PR TITLE
fix: show expression names

### DIFF
--- a/js/page.js
+++ b/js/page.js
@@ -60,7 +60,7 @@ $(document).ready(function() {
                 se.empty();
                 for (let c in model.Expressions) {
                     exp = model.Expressions[c];
-                    se.append($("<option></option>").text(c).val(exp.Name));
+                    se.append($("<option></option>").text(exp.Name.replace(/\.json$/, '')).val(exp.Name));
                 }
                 se.val("");
                 


### PR DESCRIPTION
It would be useful for translators who use l2d viewer to refer to expressions to see the internal names (e.g. `mtn_ex_032.exp3`) instead of indices (e.g. `5`).